### PR TITLE
Move settings popover button before body ending

### DIFF
--- a/components/settings-popover.tpl
+++ b/components/settings-popover.tpl
@@ -34,6 +34,4 @@
       </defs>
     </svg>
   </div>
-
-  <div class='layout_settings-tooltip'>{{ 'design_settings' | lce | escape_once }}</div>
 {%- endif -%}

--- a/components/template-tooltips.tpl
+++ b/components/template-tooltips.tpl
@@ -1,0 +1,1 @@
+<div class='layout_settings-tooltip'>{{ 'design_settings' | lce | escape_once }}</div>

--- a/components/template-tooltips.tpl
+++ b/components/template-tooltips.tpl
@@ -1,1 +1,3 @@
-<div class='layout_settings-tooltip'>{{ 'design_settings' | lce | escape_once }}</div>
+{%- if editmode -%}
+  <div class='layout_settings-tooltip'>{{ 'design_settings' | lce | escape_once }}</div>
+{%- endif -%}

--- a/layouts/blog___news.tpl
+++ b/layouts/blog___news.tpl
@@ -54,6 +54,7 @@
     {% include "footer" %}
   </div>
 
+  {% include 'template-tooltips' %}
   {% include "site-signout" %}
   {% include 'settings-popover', _blogPage: true %}
   {% include "javascripts" %}

--- a/layouts/blog_article.tpl
+++ b/layouts/blog_article.tpl
@@ -197,6 +197,7 @@
     {% include "footer" %}
   </div>
 
+  {% include 'template-tooltips' %}
   {% include "site-signout" %}
   {% include 'settings-popover', _articlePage: true %}
   {% include "javascripts" %}

--- a/layouts/common_page.tpl
+++ b/layouts/common_page.tpl
@@ -49,6 +49,7 @@
     {%- include "footer" -%}
   </div>
 
+  {% include 'template-tooltips' %}
   {%- include "site-signout" -%}
   {%- include "javascripts" -%}
 </body>

--- a/layouts/front_page.tpl
+++ b/layouts/front_page.tpl
@@ -159,6 +159,7 @@
     {% include "footer" %}
   </div>
 
+  {% include 'template-tooltips' %}
   {% include "site-signout" %}
   {% include 'settings-popover', _frontPage: true %}
   {% include "javascripts" %}

--- a/layouts/product.tpl
+++ b/layouts/product.tpl
@@ -142,6 +142,7 @@
     {% include "footer" %}
   </div>
 
+  {% include 'template-tooltips' %}
   {% include "site-signout" %}
   {% include "javascripts", _productPage: true %}
   <script>

--- a/layouts/product_list.tpl
+++ b/layouts/product_list.tpl
@@ -57,6 +57,7 @@
     {%- include "footer" -%}
   </div>
 
+  {% include 'template-tooltips' %}
   {% include 'settings-popover' %}
   {%- include "site-signout" -%}
   {%- include "javascripts" -%}

--- a/manifest.json
+++ b/manifest.json
@@ -8,16 +8,16 @@
     {
       "content_type": "page",
       "component": false,
-      "file": "layouts/front_page.tpl",
-      "layout_name": "page_front",
-      "title": "Front page"
+      "file": "layouts/product.tpl",
+      "layout_name": "product",
+      "title": "Product"
     },
     {
       "content_type": "page",
       "component": false,
-      "file": "layouts/product_list.tpl",
-      "layout_name": "product_list",
-      "title": "Product list"
+      "file": "layouts/front_page.tpl",
+      "layout_name": "page_front",
+      "title": "Front page"
     },
     {
       "content_type": "page",
@@ -29,9 +29,9 @@
     {
       "content_type": "page",
       "component": false,
-      "file": "layouts/product.tpl",
-      "layout_name": "product",
-      "title": "Product"
+      "file": "layouts/product_list.tpl",
+      "layout_name": "product_list",
+      "title": "Product list"
     },
     {
       "content_type": "blog",
@@ -46,6 +46,41 @@
       "file": "layouts/blog_article.tpl",
       "layout_name": "blog_article",
       "title": "Blog article"
+    },
+    {
+      "content_type": "component",
+      "component": true,
+      "file": "components/site-search.tpl",
+      "layout_name": "site-search",
+      "title": "site-search"
+    },
+    {
+      "content_type": "component",
+      "component": true,
+      "file": "components/template-cs-header.tpl",
+      "layout_name": "template-cs-header",
+      "title": "template-cs-header"
+    },
+    {
+      "content_type": "component",
+      "component": true,
+      "file": "components/template-cs-headings.tpl",
+      "layout_name": "template-cs-headings",
+      "title": "template-cs-headings"
+    },
+    {
+      "content_type": "component",
+      "component": true,
+      "file": "components/template-meta.tpl",
+      "layout_name": "template-meta",
+      "title": "template-meta"
+    },
+    {
+      "content_type": "component",
+      "component": true,
+      "file": "components/settings-editor.tpl",
+      "layout_name": "settings-editor",
+      "title": "settings-editor"
     },
     {
       "content_type": "component",
@@ -351,9 +386,9 @@
     {
       "content_type": "component",
       "component": true,
-      "file": "components/site-search.tpl",
-      "layout_name": "site-search",
-      "title": "site-search"
+      "file": "components/template-cs-content.tpl",
+      "layout_name": "template-cs-content",
+      "title": "template-cs-content"
     },
     {
       "content_type": "component",
@@ -389,6 +424,13 @@
       "file": "components/product-item.tpl",
       "layout_name": "product-item",
       "title": "product-item"
+    },
+    {
+      "content_type": "component",
+      "component": true,
+      "file": "components/template-tooltips.tpl",
+      "layout_name": "template-tooltips",
+      "title": "template-tooltips"
     },
     {
       "content_type": "component",
@@ -466,41 +508,6 @@
       "file": "components/menu-language-popover.tpl",
       "layout_name": "menu-language-popover",
       "title": "menu-language-popover"
-    },
-    {
-      "content_type": "component",
-      "component": true,
-      "file": "components/template-cs-content.tpl",
-      "layout_name": "template-cs-content",
-      "title": "template-cs-content"
-    },
-    {
-      "content_type": "component",
-      "component": true,
-      "file": "components/template-cs-header.tpl",
-      "layout_name": "template-cs-header",
-      "title": "template-cs-header"
-    },
-    {
-      "content_type": "component",
-      "component": true,
-      "file": "components/template-cs-headings.tpl",
-      "layout_name": "template-cs-headings",
-      "title": "template-cs-headings"
-    },
-    {
-      "content_type": "component",
-      "component": true,
-      "file": "components/template-meta.tpl",
-      "layout_name": "template-meta",
-      "title": "template-meta"
-    },
-    {
-      "content_type": "component",
-      "component": true,
-      "file": "components/settings-editor.tpl",
-      "layout_name": "settings-editor",
-      "title": "settings-editor"
     }
   ],
   "assets": [


### PR DESCRIPTION
Kuna modulaarsel lehel asus tooltipi element `body` sees olevas elemendis, mille `z-index` oli madalam kui toolbaril, siis see jäi toolbari taha. 

Muudatusega viidi tooltip eraldi komponenti, et saaks hiljem ka teisi lisada ja sisestati enne `body` lõppu.

Close #40 