### PR TITLE
Remove double margin for product list titles

### DIFF
--- a/components/product-list-block.tpl
+++ b/components/product-list-block.tpl
@@ -17,11 +17,7 @@
               {%- if level_1.layout_title == product_list_layout -%}
                 {% include 'content-item', _imageData: level_1.data[itemImageKey], _entityData: level_1, _itemType: 'page', _id: level_1.page_id, _targetWidth: '600' %}
                 <div class="product_item-details--alignment">
-                  <a class="p14 mar_t-16" href="{{ level_1.url }}">
-                    <div class="p14 mar_t-16 bold product_item-title">
-                      {{ level_1.title }}
-                    </div>
-                  </a>
+                  <a class="p14 mar_t-16 bold product_item-title" href="{{ level_1.url }}">{{ level_1.title }}</a>
                   <div class="flex_box product_item-details">
                     <a class="product_item-btn p-rel" href="{{ level_1.url }}">{{ "look_closer" | lc | escape_once }}</a>
                   </div>
@@ -53,11 +49,7 @@
                   {%- if item_child.layout_title == product_list_layout -%}
                     {% include 'content-item', _imageData: item_child.data[itemImageKey], _entityData: item_child, _itemType: 'page', _id: item_child.page_id, _targetWidth: '600' %}
                     <div class="product_item-details--alignment">
-                      <a class="p14 mar_t-16" href="{{ item_child.url }}">
-                        <div class="p14 mar_t-16 bold product_item-title">
-                          {{ item_child.title }}
-                        </div>
-                      </a>
+                      <a class="p14 mar_t-16 bold product_item-title" href="{{ item_child.url }}">{{ item_child.title }}</a>
                       <div class="flex_box product_item-details">
                         <a class="product_item-btn p-rel" href="{{ item_child.url }}">{{ "look_closer" | lc | escape_once }}</a>
                       </div>


### PR DESCRIPTION
Product list and product page titles are now displayed on the same height
Closes #70 