### PR TITLE
Support editable product name and description on autogenerated product page

### DIFF
--- a/layouts/auto_generated_product.tpl
+++ b/layouts/auto_generated_product.tpl
@@ -66,7 +66,7 @@
                 <div class="flex_row flex_a-center flex_j-space-between mar_b-32">
                   <div class="content-body content-formatted" data-search-indexing-allowed="true">
                     <h3>
-                      {{- product.title -}}
+                      {{- editable product.name -}}
                     </h3>
 
                     {%- if product.out_of_stock? -%}
@@ -83,9 +83,9 @@
                       {%- endif -%}
                       {{ product.price_max_with_tax | money_with_currency: product.currency }}
                   </div>
-                  {%- if product.description != blank -%}
+                  {%- if editmode or product.description != blank -%}
                     <div class="content-product-description">
-                      {{- product.description -}}
+                      {{- editable product.description -}}
                     </div>
                   {%- endif -%}
                   {% content bind=product %}

--- a/layouts/auto_generated_product.tpl
+++ b/layouts/auto_generated_product.tpl
@@ -66,7 +66,7 @@
                 <div class="flex_row flex_a-center flex_j-space-between mar_b-32">
                   <div class="content-body content-formatted" data-search-indexing-allowed="true">
                     <h3>
-                      {{- editable product.name -}}
+                      {%- editable product.name -%}
                     </h3>
 
                     {%- if product.out_of_stock? -%}
@@ -85,7 +85,7 @@
                   </div>
                   {%- if editmode or product.description != blank -%}
                     <div class="content-product-description">
-                      {{- editable product.description -}}
+                      {%- editable product.description -%}
                     </div>
                   {%- endif -%}
                   {% content bind=product %}


### PR DESCRIPTION
Closes #82

Support editable product name and description on autogenerated product page

`editable product.name` and `editable product.description`