### PR TITLE
Move content area to after buy button

### DIFF
--- a/layouts/auto_generated_product.tpl
+++ b/layouts/auto_generated_product.tpl
@@ -88,10 +88,12 @@
                       {%- editable product.description -%}
                     </div>
                   {%- endif -%}
-                  {% content bind=product %}
+
                   <div class="content-buy-button mar_t-32">
                     {% include "buy-button" %}
                   </div>
+
+                  {% content bind=product %}
                 </section>
               </div>
             </div>


### PR DESCRIPTION
For the Nuuk auto-generated product template to act similarly to other templates, the content area under the description area is moved under the buy button (as the description area supports our text editor & adding images).

Closes #89.