### PR TITLE
Fix lazy-image sizes and srcset attributes

### DIFF
--- a/components/lazy-image.tpl
+++ b/components/lazy-image.tpl
@@ -12,7 +12,7 @@
 
 {%- if _targetWidth != blank -%}
   {%- assign _maxWidth = _targetWidth | plus:0 -%}
-  {%- assign sizes = "(min-width: " | append: _targetWidth | append: "px) " | append: _targetWidth | append: 'px' -%}
+  {%- assign sizes = "(min-width: " | append: _targetWidth | append: "px) " | append: _targetWidth | append: 'px' | append: ', 100vw' -%}
 {%- else -%}
   {%- assign _maxWidth = _data.width -%}
   {%- assign sizes = '100vw' -%}

--- a/components/lazy-image.tpl
+++ b/components/lazy-image.tpl
@@ -27,10 +27,8 @@
     {%- if _data[imageSizes].size >= 1 %}
       data-srcset="
         {%- for image in _data[imageSizes] -%}
-          {{image[urlKey]}} {{image.width}}w
-          {%- unless forloop.last -%}
-          ,
-          {%- endunless -%}
+          {{ image[urlKey] }}{%- if image.width != blank %} {{ image.width }}w{%- endif -%}
+          {%- unless forloop.last -%}, {%- endunless -%}
         {%- endfor -%}
       "
     {%- endif -%}

--- a/components/lazy-image.tpl
+++ b/components/lazy-image.tpl
@@ -27,8 +27,11 @@
     {%- if _data[imageSizes].size >= 1 %}
       data-srcset="
         {%- for image in _data[imageSizes] -%}
-          {{ image[urlKey] }}{%- if image.width != blank %} {{ image.width }}w{%- endif -%}
-          {%- unless forloop.last -%}, {%- endunless -%}
+          {%- capture srcsetString -%}
+            {%- if image.width != blank %}{{ image[urlKey] }} {{ image.width }}w{%- endif -%}
+          {%- endcapture -%}
+          {{- srcsetString -}}
+          {%- unless forloop.last or srcsetString == blank -%}, {% endunless -%}
         {%- endfor -%}
       "
     {%- endif -%}


### PR DESCRIPTION
The `lazy-image.tpl` component output invalid srcsets, because the `image.width` property didn't exist on the image.

Added a check for if the `image.width` property exists. If not, that url with the width descriptor / pixel density descriptor will not be added at all.

Also added the [required media condition](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#:~:text=to%20insecure%20origins.-,sizes,-One%20or%20more) for the last item in the `sizes` array.

Closes #81.