### PR TITLE
Use the crossFade effect to fix mobile slider

### DIFF
--- a/components/swiper-js.tpl
+++ b/components/swiper-js.tpl
@@ -49,7 +49,7 @@
           },
           effect: sliderEffect,
           fadeEffect: {
-            crossFade: sliderEffect === 'fade' ? true : false
+            crossFade: sliderEffect === 'fade'
           },
           speed: 800,
           parallax: true,

--- a/components/swiper-js.tpl
+++ b/components/swiper-js.tpl
@@ -48,6 +48,9 @@
             onlyInViewport: false,
           },
           effect: sliderEffect,
+          fadeEffect: {
+            crossFade: sliderEffect === 'fade' ? true : false
+          },
           speed: 800,
           parallax: true,
           allowTouchMove: conditionalBool,


### PR DESCRIPTION
The SwiperJS [documentation (API) states](https://swiperjs.com/swiper-api#:~:text=Note%20that%20crossFade%20should%20be%20set%20to%20true%20in%20order%20to%20avoid%20seeing%20content%20behind%20or%20underneath.) that "`crossFade` should be
set to `true` in order to avoid seeing content behind or underneath".

Closes #102.