### PR TITLE
Fix header mainmenu bound variables

### DIFF
--- a/components/template-cs-header.tpl
+++ b/components/template-cs-header.tpl
@@ -168,8 +168,8 @@
     "icon": "uppercase",
     "scope": "global",
     "boundVariables": [
-      "header-mainmenu-hover-text-transform",
-      "header-mainmenu-active-text-transform"
+      "--header-mainmenu-hover-text-transform",
+      "--header-mainmenu-active-text-transform"
     ]
   */
   --header-mainmenu-text-transform: none;
@@ -239,7 +239,7 @@
     "icon": "uppercase",
     "scope": "global",
     "boundVariables": [
-      "header-mainmenu-active-text-transform"
+      "--header-mainmenu-active-text-transform"
     ]
   */
   --header-mainmenu-hover-text-transform: none;

--- a/sources/components/custom-styles/template-cs-header.scss
+++ b/sources/components/custom-styles/template-cs-header.scss
@@ -201,8 +201,8 @@
     "icon": "uppercase",
     "scope": "global",
     "boundVariables": [
-      "header-mainmenu-hover-text-transform",
-      "header-mainmenu-active-text-transform"
+      "--header-mainmenu-hover-text-transform",
+      "--header-mainmenu-active-text-transform"
     ]
   */
   #{--header-mainmenu-text-transform}: none;
@@ -280,7 +280,7 @@
     "icon": "uppercase",
     "scope": "global",
     "boundVariables": [
-      "header-mainmenu-active-text-transform"
+      "--header-mainmenu-active-text-transform"
     ]
   */
   #{--header-mainmenu-hover-text-transform}: none;


### PR DESCRIPTION
Use syntactically correct variables for header bound variables, so that they also apply correctly.
To test, change Header > Main menu > Normal > Text transform setting in Design editor and verify that Hover and Active values are also changed.
Closes #111 