### PR TITLE
Add tags to all settings applied only in desktop view

### DIFF
--- a/components/settings-blog-page-layout.tpl
+++ b/components/settings-blog-page-layout.tpl
@@ -32,7 +32,7 @@
         settingsBtn: document.querySelector('.js-blog-layout-settings-editor'),
         menuItems: [
           {
-            "title": {{ "blog_layout" | lce | json }},
+            "title": "{{ "blog_layout" | lce }} ({{ "desktop" | lce }})",
             "type": "radio",
             "key": "blog_layout",
             "list": [

--- a/components/settings-menu.tpl
+++ b/components/settings-menu.tpl
@@ -47,7 +47,7 @@
           settingsBtn: document.querySelector('.js-menu-settings-btn'),
           menuItems: [
             {
-              "title": {{ "menu_alignment" | lce | json }},
+              "title": "{{ "menu_alignment" | lce }} ({{ "desktop" | lce }})",
               "type": "radio",
               "key": "positioning",
               "list": [
@@ -70,7 +70,7 @@
               ]
             },
             {
-              "title": {{ "active_page_indicator" | lce | json }},
+              "title": "{{ "active_page_indicator" | lce }} ({{ "desktop" | lce }})",
               "type": "radio",
               "key": "indicator",
               "list": [
@@ -89,14 +89,14 @@
             {%- assign pxTr = "units.px" | lce -%}
             {%- assign sideMenuCombinedTr = sideMenuWidthTr | append: ' (' | append: pxTr | append: ')' -%}
             {
-              "title": {{ sideMenuCombinedTr | json }},
+              "title": "{{ sideMenuCombinedTr }} ({{ "desktop" | lce }})",
               "type": "number",
               "min": 1,
               "key": "max_width",
               "placeholder": {{ sideMenuCombinedTr | json }}
             },
             {
-              "title": {{ "max_no_of_menu_pages" | lce | json }},
+              "title": "{{ "max_no_of_menu_pages" | lce }} ({{ "desktop" | lce }})",
               "type": "number",
               "key": "max_elements",
               "placeholder": {{ "max_no_of_menu_pages" | lce | json }},

--- a/components/settings-modular-content.tpl
+++ b/components/settings-modular-content.tpl
@@ -70,7 +70,7 @@
           valuesObj.col_h_padding = "{{_defaultBlockObj.default.col_h_padding}}";
         {%- endif -%}
       }
-      
+
       if (!('col_min_width' in valuesObj)) {
         {%- if _defaultBlockObj[blockColumnsSettingsKey].col_min_width -%}
           valuesObj.col_min_width = "{{_defaultBlockObj[blockColumnsSettingsKey].col_min_width}}";
@@ -143,15 +143,6 @@
                 {"title": "5", "value": 5}
               ]
             },
-            {%- assign blockMaxWidthTr = "max_width" | lce -%}
-            {%- assign blockMaxWidthCombinedTr = blockMaxWidthTr | append: ' (%)' -%}
-            {
-              "title": {{ blockMaxWidthCombinedTr| json }},
-              "type": "number",
-              "min": 1,
-              "key": "block_max_width",
-              "placeholder": {{ blockMaxWidthCombinedTr| json }}
-            },
             {%- assign verticalSpacingTr = "vertical_spacing" | lce -%}
             {%- assign pxTr = "units.px" | lce -%}
             {%- assign verticalSpacingCombinedTr = verticalSpacingTr | append: ' (' | append: pxTr | append: ')' -%}
@@ -162,8 +153,17 @@
               "key": "block_v_padding",
               "placeholder": {{verticalSpacingCombinedTr | json }}
             },
+            {%- assign blockMaxWidthTr = "max_width" | lce -%}
+            {%- assign blockMaxWidthCombinedTr = blockMaxWidthTr | append: ' (%)' -%}
             {
-              "title": {{ "column_distribution" | lce | json }},
+              "title": "{{ blockMaxWidthCombinedTr }} ({{ "desktop" | lce }})" ,
+              "type": "number",
+              "min": 1,
+              "key": "block_max_width",
+              "placeholder": {{ blockMaxWidthCombinedTr| json }}
+            },
+            {
+              "title": "{{ "column_distribution" | lce }} ({{ "desktop" | lce }})",
               "type": "select",
               "key": "block_justification",
               "list": [
@@ -188,7 +188,7 @@
             {%- assign pxTr = "units.px" | lce -%}
             {%- assign colMaxWidthCombinedTr = colMaxWidthTr | append: ' (' | append: pxTr | append: ')' -%}
             {
-              "title": {{ colMaxWidthCombinedTr | json }},
+              "title": "{{ colMaxWidthCombinedTr }} ({{ "desktop" | lce }})",
               "type": "number",
               "min": 1,
               "key": "col_max_width",
@@ -198,7 +198,7 @@
             {%- assign pxTr = "units.px" | lce -%}
             {%- assign colMinWidthCombinedTr = colMinWidthTr | append: ' (' | append: pxTr | append: ')' -%}
             {
-              "title": {{ colMinWidthCombinedTr | json }},
+              "title": "{{ colMinWidthCombinedTr }} ({{ "desktop" | lce }})",
               "type": "number",
               "min": 1,
               "key": "col_min_width",
@@ -208,14 +208,14 @@
             {%- assign pxTr = "units.px" | lce -%}
             {%- assign colHPadCombinedTr = colHPadTr | append: ' (' | append: pxTr | append: ')' -%}
             {
-              "title": {{ colHPadCombinedTr | json }},
+              "title": "{{ colHPadCombinedTr }} ({{ "desktop" | lce }})",
               "type": "number",
               "min": 0,
               "key": "col_h_padding",
               "placeholder": {{ colHPadCombinedTr | json }}
             },
             {
-              "title": {{ "column_distribution" | lce | json }},
+              "title": "{{ "column_distribution" | lce }} ({{ "desktop" | lce }})",
               "type": "select",
               "key": "col_justification",
               "list": [

--- a/components/settings-swiper.tpl
+++ b/components/settings-swiper.tpl
@@ -51,7 +51,7 @@
             }
           },
           {
-            "title": {{ "content_position" | lce | json }},
+            "title": "{{ "content_position" | lce }} ({{ "desktop" | lce }})",
             "type": "radio",
             "key": "content_position",
             "list": [


### PR DESCRIPTION
To help differentiate settings that are only applied in desktop view, add a "desktop" tag to all such settings.

Closes #112 

Tag is added to following settings:

- Front page header
  - Content position

- Navigation
  - Menu alignment
  - Side menu width
  - Maximum number of top menu pages

- Blog layout
  - Blog layout

- Block settings
  - Maximum width
  - Column distribution
  - Maximum column width
  - Minimum column width
  - Space between columns
  - Column distribution