### PR TITLE
Do not reinitialize swiper on every resize

### DIFF
--- a/components/swiper-js.tpl
+++ b/components/swiper-js.tpl
@@ -3,10 +3,6 @@
   <script>
     initSwiper();
 
-    $( window ).resize(function() {
-      initSwiper();
-    });
-
     function initSwiper() {
       {%- unless editmode -%}
         var conditionalBool = true;


### PR DESCRIPTION
Previously front page swiper was re-initialized every time when window was resized. This caused the swiper to flash on slide change after resizing the window.

Closes #144 

Testing:
Add more than two slides to front page swiper and set them to change automatically. Make sure that when resizing window, slides do not flash on change.